### PR TITLE
Exclude polymer if configured, and babel for components

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -138,7 +138,6 @@ class ClientJS extends NxusModule {
       imports.push(this.config.reincludeComponentScripts[s])
     }
     imports.push(outputHTML)
-    imports.push(outputJS)
 
     templater.on('renderContext.'+templateName, () => {
       return {
@@ -172,8 +171,8 @@ class ClientJS extends NxusModule {
       exclude += " --strip-exclude " + s
     }
     
-    let cmd = "vulcanize " + exclude + " --inline-script --inline-html " + entry
-    cmd += " | crisper --html " + outputFile + " --js " + outputJS
+    let cmd = "vulcanize" + exclude + " --inline-script --inline-html " + entry
+    cmd += " | crisper --script-in-head false --html " + outputFile + " --js " + outputJS
     cmd += " ; babel -o " + outputJS + " " + outputJS
     this.log.debug("Componentizing:", cmd)
     child_process.execAsync(cmd).then((error, stdout, stderr) => {


### PR DESCRIPTION
This cleans up componentize to work with babel, expects cooperating config in the application for all polymer deps unfortunately to leave them out of the vulcanize output and instead directly move their imports to the `imports` page context, ala:

```
  "client-js": {
    "webcomponentsURL": "/js-deps/webcomponentsjs/webcomponents-lite.min.js",
    "reincludeComponentScripts": {
      "polymer/polymer.html": "/js-deps/polymer/polymer.html",
      "plotly-plot/plotly-plot.html": "/js-deps/plotly-plot/plotly-plot.html"
    },
```