### PR TITLE
Cache multiple includeComponent calls for the same output files

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -170,8 +170,16 @@ class ClientJS extends NxusModule {
     if (this._componentCache[entry]) {
       let [p, h, j] = this._componentCache[entry]
       return p.then(() => {
-        fs.unlinkSync(outputFile)
-        fs.unlinkSync(outputJS)
+        try {
+          let fstat = fs.lstatSync(outputFile)
+          if (fstat.isSymbolicLink() || fstat.isFile())
+            fs.unlinkSync(outputFile)
+        } catch (e) {}
+        try {
+        let jstat = fs.lstatSync(outputJS)
+        if (jstat.isSymbolicLink() || jstat.isFile())
+          fs.unlinkSync(outputJS)
+        } catch (e) {}
         fs.symlinkSync(h, outputFile)
         fs.symlinkSync(j, outputJS)
       })

--- a/src/index.js
+++ b/src/index.js
@@ -78,6 +78,7 @@ class ClientJS extends NxusModule {
   constructor () {
     super()
     this._outputPaths = {}
+    this._componentCache = {}
 
     if(_.isEmpty(this.config.babel)) this.config.babel = _.omit(require('rc')('babel', {}), '_', 'config', 'configs')
     this._fromConfigBundles(app)
@@ -166,6 +167,16 @@ class ClientJS extends NxusModule {
       router.staticRoute(outputRoute, outputPath)
     }
 
+    if (this._componentCache[entry]) {
+      let [p, h, j] = this._componentCache[entry]
+      return p.then(() => {
+        fs.unlinkSync(outputFile)
+        fs.unlinkSync(outputJS)
+        fs.symlinkSync(h, outputFile)
+        fs.symlinkSync(j, outputJS)
+      })
+    }
+
     let exclude = ""
     for (let s in this.config.reincludeComponentScripts) {
       exclude += " --strip-exclude " + s
@@ -173,13 +184,20 @@ class ClientJS extends NxusModule {
     
     let cmd = "vulcanize" + exclude + " --inline-script --inline-html " + entry
     cmd += " | crisper --script-in-head false --html " + outputFile + " --js " + outputJS
-    cmd += " ; babel -o " + outputJS + " " + outputJS
     this.log.debug("Componentizing:", cmd)
-    child_process.execAsync(cmd).then((error, stdout, stderr) => {
+    // wait for componentize but not babel
+    let promise = child_process.execAsync(cmd).then((error, stdout, stderr) => {
       if (error) this.log.error("Componentize Error", error)
+      if (stderr) this.log.error("Componentize Error", stderr)
+      child_process.execAsync("babel -o " + outputJS + " " + outputJS)
+        .then((error, stdout, stderr) => {
+          if (error) this.log.error("Babel Error", error)
+          if (stderr) this.log.error("Babel Error", stderr)
+        })
     }).catch((e) => {
       this.log.error("Componentize Error", e)
     })
+    this._componentCache[entry] = [promise, outputFile, outputJS]
   }
   
   /**


### PR DESCRIPTION
 and write symlinks rather than re-processing for each include.