### PR TITLE
copy files rather than symlinks

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -217,8 +217,8 @@ class ClientJS extends NxusModule {
         if (jstat.isSymbolicLink() || jstat.isFile())
           fs.unlinkSync(outputJS)
         } catch (e) {}
-        fs.symlinkSync(h, outputFile)
-        fs.symlinkSync(j, outputJS)
+        fs.copySync(h, outputFile)
+        fs.copySync(j, outputJS)
       })
     }
 


### PR DESCRIPTION
believe this was the source of heroku 404s for these files.

cc @davidkellerman