### PR TITLE
Wrong path used to refer to bundled component.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -167,9 +167,8 @@ class ClientJS extends NxusModule {
   includeScript(templateName, script) {
     let scriptName = path.basename(script)
     let outputPath = path.join(morph.toDashed(templateName), scriptName)
-    let outputUrl = path.join(this.config.routePrefix,outputPath)
 
-    let imports, scripts, headScripts
+    let imports, headScripts
 
     if (script.slice(-4) == 'html') {
       outputPath += ".js"
@@ -180,10 +179,9 @@ class ClientJS extends NxusModule {
       headScripts = [
         this.config.webcomponentsURL,
       ]
-      scripts = [outputUrl]
-    } else {
-      scripts = [outputUrl]
     }
+
+    let scripts = [path.join(this.config.routePrefix,outputPath)]
 
     templater.on('renderContext.'+templateName, () => {
       return {

--- a/src/index.js
+++ b/src/index.js
@@ -168,7 +168,7 @@ class ClientJS extends NxusModule {
     let scriptName = path.basename(script)
     let outputPath = path.join(morph.toDashed(templateName), scriptName)
 
-    let imports, headScripts
+    let imports = [], headScripts = []
 
     if (script.slice(-4) == 'html') {
       outputPath += ".js"
@@ -221,16 +221,25 @@ class ClientJS extends NxusModule {
     let ignoreLinks = Object.keys(this.config.reincludeComponentScripts).map((x) => {
       return new RegExp(x+"$")
     })
-    
+
     var options = {
       entry: path.resolve(entry),
       output: {
         filename: outputFilename,
-        path: outputPath,
-        sourceMapFilename: outputFilename+'.map'
+        path: outputPath
       },
       devtool: sourceMap ? sourceMap : false,
       watch: this.config.watchify,
+      resolve: {
+        modules: [
+          "node_modules",
+          "bower_components"
+        ],
+        descriptionFiles: [
+          "package.json",
+          "bower.json"
+        ]
+      },
       module: {
         rules: [
           {


### PR DESCRIPTION
When bundling a component, an extra `.js` is added to the output name,
but this wasn't reflected in the URL referring to the bundled output.