### PR TITLE
Improved watching/caching

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "babel-loader": "^7.1.2",
     "babel-preset-env": "^1.6.0",
     "bluebird": "^3.0.6",
+    "chokidar": "^3.1.1",
     "css-loader": "^3.2.0",
     "fs-extra": "^3.0.1",
     "imports-loader": "^0.7.1",
@@ -48,7 +49,7 @@
     "traverse": "^0.6.6",
     "uglifyjs-webpack-plugin": "^1.0.0-beta.2",
     "underscore": "^1.8.3",
-    "webpack": "^4",
+    "webpack": "^4.40.0",
     "webpack-combine-loaders": "^2.0.4"
   },
   "devDependencies": {


### PR DESCRIPTION
Added chokidar to replace webpack watching so that the cache plugin can work. Otherwise, webpack doesnt see any file paths that should be watched if build isnt required.

@loppear would appreciate your eyes on this given its a bit of a rewrite.