### PR TITLE
singleBundle config for one app.js

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -119,6 +119,8 @@ class ClientJS extends NxusModule {
     this._fromConfigBundles(app)
 
     this._builders = []
+    this._singleBundleScripts = []
+    this._singleBundleName = 'app.js'
     this.readyToBuild = new Promise((resolve, reject) => {
       app.on('launch', () => {
         resolve()
@@ -141,6 +143,7 @@ class ClientJS extends NxusModule {
       assetFolder: '.tmp/clientjs',
       webcomponentsURL: '/js/webcomponentsjs/webcomponents-lite.min.js',
       entries: {},
+      singleBundle: false,
       sourceMap: app.config.NODE_ENV != 'production' ? 'cheap-module-eval-source-map' : false,
       buildSeries: false,
       buildOnly: false,
@@ -165,6 +168,11 @@ class ClientJS extends NxusModule {
     if (this.config.buildNone) return
     let op = this.config.buildSeries ? Promise.mapSeries : Promise.map
     return op(this._builders, (x) => {return x()})
+      .then(() => {
+        if (this._singleBundleScripts.length > 0) {
+          return this._bundle(this._singleBundleScripts, this._singleBundleName)
+        }
+      })
   }
 
   /**
@@ -189,7 +197,8 @@ class ClientJS extends NxusModule {
       ]
     }
 
-    let scripts = [path.join(this.config.routePrefix,outputPath)]
+    let scripts = [path.join(this.config.routePrefix,
+                             (this.config.singleBundle ? this._singleBundleName : outputPath))]
 
     templater.on('renderContext.'+templateName, () => {
       return {
@@ -242,7 +251,7 @@ class ClientJS extends NxusModule {
     }
 
     var options = {
-      entry: path.resolve(entry),
+      entry: _.isArray(entry) ? _.uniq(entry.map(e => path.resolve(e))) : path.resolve(entry),
       output: {
         filename: outputFilename,
         path: outputPath
@@ -335,6 +344,14 @@ class ClientJS extends NxusModule {
    * @param  {[type]} output the output path to use in the browser to access the bundled source
    */
   bundle(entry, output) {
+    if (this.config.singleBundle) {
+      this._singleBundleScripts.push(entry)
+    } else {
+      return this._bundle(entry, output)
+    }
+  }
+
+  _bundle(entry, output) {
     this.log.debug('Bundling', entry, "to", output)
 
     let outputDir = path.dirname(output)

--- a/src/index.js
+++ b/src/index.js
@@ -256,7 +256,7 @@ class ClientJS extends NxusModule {
         filename: outputFilename,
         path: outputPath
       },
-      mode: app.config.NODE_ENV,
+      mode: app.config.NODE_ENV || 'production',
       plugins: [
         new OnlyIfChangedPlugin({
           cacheDirectory: path.join(opts.rootDir, '.tmp/cache'),


### PR DESCRIPTION
Here's a first stab at optionally combining all `includeScript` scripts into a single webpack bundle.

Things noted in initial testing on 100mhl:
- app.js is 2.2M, vs individual page-targeted bundles of 0.7-1.5M. (Not unreasonable, as a visit to two parts of the site is already a savings, but worth digging in more as I wouldn't have expected the dependency trees of non-shared components to be so big.)
- throwing some ignorable errors for some admin scripts that are now included on the frontend but I think are using `renderContext` `scripts` directly rather than includeScripts for external deps (datatables). So external (non-bundled) deps are doing to have to be considered here.
- there's some bug TBD with the non-singleBundle behavior here on the particular chart implementation there.

So I think this is usable to test whether a single bundle works for other projects, but not yet ready to merge.