### PR TITLE
Support new boot stage 'build', remove buildOnly config

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "fs-extra": "^3.0.1",
     "imports-loader": "^0.7.1",
     "morph": "^0.2.0",
-    "nxus-core": "^4.0.0",
+    "nxus-core": "https://github.com/nxus/core.git#feature/boot-stages-build-connect",
     "nxus-router": "^4.0.0",
     "nxus-templater": "^4.0.0",
     "only-if-changed-webpack-plugin": "https://github.com/vhadianto/only-if-changed-webpack-plugin.git",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "postversion": "npm run build-docs && git push && git push --tags",
     "test": "NODE_ENV=test mocha --compilers js:babel-register -R spec src/test",
     "compile": "rm -rf lib/; babel src --ignore src/test --out-dir lib",
+    "prepare": "npm run compile",
     "prepublish": "npm run compile",
     "postpublish": "npm run build-docs && npm run publish-docs",
     "build-docs": "export NAME=`npm view . name`; export VERSION=`npm view . version`; documentation readme ./src/index.js --name $NAME --project-version $VERSION --readme-file ./README.md -s $NAME",

--- a/src/index.js
+++ b/src/index.js
@@ -46,7 +46,7 @@ import mkdirp from 'mkdirp'
  *         'buildSeries': false // Whether to run bundle builds in series instead of parallel, for deploy scripts
  *       }
  *
- *   'buildOnly' config option DEPRECATED: use `--exitAfter=build` cmdline instead.
+ *   'buildOnly' config option DEPRECATED: use `nxus_exitAfter=build` cmdline instead.
  * 
  * ## Usage
  *


### PR DESCRIPTION
Depends on nxus/core#126

`build-js-components` script now just

`NODE_ENV=production DEBUG=nxus:clientjs:* nxus_client_js__buildSeries=1 nxus_exitAfter=build npm start`

rather than needing to disable any problematic startup modules.